### PR TITLE
Feature/add test config for ceda ukcp

### DIFF
--- a/configurations/test_catalogue_ukcp.json
+++ b/configurations/test_catalogue_ukcp.json
@@ -1,0 +1,5 @@
+{
+  "url": "https://api.stac.ceda.ac.uk/collections/ukcp",
+  "path": "supported-datasets/ceda-stac-fastapi/ukcp",
+  "schedule": "5 10 * * *"
+}

--- a/configurations/test_catalogue_ukcp.json
+++ b/configurations/test_catalogue_ukcp.json
@@ -1,5 +1,5 @@
 {
   "url": "https://api.stac.ceda.ac.uk/collections/ukcp",
   "path": "supported-datasets/ceda-stac-fastapi/ukcp",
-  "schedule": "5 10 * * *"
+  "schedule": "12 10 * * *"
 }


### PR DESCRIPTION
Added new test configuration to harvest CEDA UKCP dataset.
This aligns with the latest `stac-harvester` and `harvest-transformer` changes to better support nested catalog structures